### PR TITLE
conda clean requires flags.

### DIFF
--- a/python/jupyter-nbextensions/Dockerfile
+++ b/python/jupyter-nbextensions/Dockerfile
@@ -8,7 +8,7 @@ MAINTAINER Andrew White <andrew.white@rochester.edu>
 
 USER jovyan
 
-RUN conda install -c conda-forge jupyter_contrib_nbextensions && conda clean
+RUN conda install -c conda-forge jupyter_contrib_nbextensions && conda clean -a -y
 RUN jupyter contrib nbextension install --user
 RUN jupyter nbextension enable spellcheck/main
 RUN jupyter nbextension enable chrome-clipboard/main


### PR DESCRIPTION
Hi! Very happy to find a Docker image that enables these extensions. I tried building from Dockerfile though and found that I had to add flags for `conda clean` to work. Thanks, Andrew.